### PR TITLE
Bump up TFLint version to v0.32.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM alpine:3.14 as builder
 
-ARG TFLINT_VERSION=0.31.0
-ARG AWS_VERSION=0.6.0
-ARG AZURERM_VERSION=0.12.0
-ARG GOOGLE_VERSION=0.11.0
+ARG TFLINT_VERSION=0.32.0
+ARG AWS_VERSION=0.7.1
+ARG AZURERM_VERSION=0.13.0
+ARG GOOGLE_VERSION=0.12.0
 
 RUN wget -O /tmp/tflint.zip https://github.com/terraform-linters/tflint/releases/download/v"${TFLINT_VERSION}"/tflint_linux_amd64.zip \
   && unzip /tmp/tflint.zip -d /usr/local/bin \

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ docker pull ghcr.io/terraform-linters/tflint-bundle
 
 Bundled versions:
 
-- TFLint v0.31.0
-- tflint-ruleset-aws v0.6.0
-- tflint-ruleset-azurerm v0.12.0
-- tflint-ruleset-google v0.11.0
+- TFLint v0.32.0
+- tflint-ruleset-aws v0.7.1
+- tflint-ruleset-azurerm v0.13.0
+- tflint-ruleset-google v0.12.0
 
 These ruleset plugins are installed manually. If you want to enable it, just set `enabled = true` without specifying the version.
 


### PR DESCRIPTION
https://github.com/terraform-linters/tflint/releases/tag/v0.32.0
https://github.com/terraform-linters/tflint-ruleset-aws/releases/tag/v0.7.1
https://github.com/terraform-linters/tflint-ruleset-azurerm/releases/tag/v0.13.0
https://github.com/terraform-linters/tflint-ruleset-google/releases/tag/v0.12.0