### PR TITLE
Bump TFLint and ruleset versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM alpine:3.16.2 as builder
 
-ARG TFLINT_VERSION=0.39.3
-ARG AWS_VERSION=0.16.1
-ARG AZURERM_VERSION=0.17.1
-ARG GOOGLE_VERSION=0.19.0
+ARG TFLINT_VERSION=0.40.0
+ARG AWS_VERSION=0.17.0
+ARG AZURERM_VERSION=0.18.0
+ARG GOOGLE_VERSION=0.20.0
 
 RUN wget -O /tmp/tflint.zip https://github.com/terraform-linters/tflint/releases/download/v"${TFLINT_VERSION}"/tflint_linux_amd64.zip \
   && unzip /tmp/tflint.zip -d /usr/local/bin \

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ docker pull ghcr.io/terraform-linters/tflint-bundle
 
 Bundled versions:
 
-- TFLint v0.39.3
-- tflint-ruleset-aws v0.16.1
-- tflint-ruleset-azurerm v0.17.1
-- tflint-ruleset-google v0.19.0
+- TFLint v0.40.0
+- tflint-ruleset-aws v0.17.0
+- tflint-ruleset-azurerm v0.18.0
+- tflint-ruleset-google v0.20.0
 
 These ruleset plugins are installed manually. If you want to enable it, just set `enabled = true` without specifying the version.
 


### PR DESCRIPTION
- https://github.com/terraform-linters/tflint/releases/tag/v0.40.0
- https://github.com/terraform-linters/tflint-ruleset-aws/releases/tag/v0.17.0
- https://github.com/terraform-linters/tflint-ruleset-azurerm/releases/tag/v0.18.0
- https://github.com/terraform-linters/tflint-ruleset-google/releases/tag/v0.20.0