### PR TITLE
Add support for multi-arch images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@v4
@@ -28,8 +30,7 @@ jobs:
     - name: Build and push
       uses: docker/build-push-action@v3
       with:
+        platforms: 'linux/amd64,linux/arm64/v8'
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-    - name: docker run
-      run: docker run ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.version }} -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,27 @@
-FROM alpine:3.16.2 as builder
+FROM --platform=$BUILDPLATFORM alpine:3.16.2 as builder
+
+ARG TARGETOS TARGETARCH
 
 ARG TFLINT_VERSION=0.41.0
 ARG AWS_VERSION=0.17.0
 ARG AZURERM_VERSION=0.18.0
 ARG GOOGLE_VERSION=0.20.0
 
-RUN wget -O /tmp/tflint.zip https://github.com/terraform-linters/tflint/releases/download/v"${TFLINT_VERSION}"/tflint_linux_amd64.zip \
+RUN wget -O /tmp/tflint.zip https://github.com/terraform-linters/tflint/releases/download/v"${TFLINT_VERSION}"/tflint_"${TARGETOS}"_"${TARGETARCH}".zip \
   && unzip /tmp/tflint.zip -d /usr/local/bin \
   && rm /tmp/tflint.zip
 
 RUN mkdir -p ~/.tflint.d/plugins
 
-RUN wget -O /tmp/tflint-ruleset-aws.zip https://github.com/terraform-linters/tflint-ruleset-aws/releases/download/v"${AWS_VERSION}"/tflint-ruleset-aws_linux_amd64.zip \
+RUN wget -O /tmp/tflint-ruleset-aws.zip https://github.com/terraform-linters/tflint-ruleset-aws/releases/download/v"${AWS_VERSION}"/tflint-ruleset-aws_"${TARGETOS}"_"${TARGETARCH}".zip \
   && unzip /tmp/tflint-ruleset-aws.zip -d ~/.tflint.d/plugins \
   && rm /tmp/tflint-ruleset-aws.zip
 
-RUN wget -O /tmp/tflint-ruleset-azurerm.zip https://github.com/terraform-linters/tflint-ruleset-azurerm/releases/download/v"${AZURERM_VERSION}"/tflint-ruleset-azurerm_linux_amd64.zip \
+RUN wget -O /tmp/tflint-ruleset-azurerm.zip https://github.com/terraform-linters/tflint-ruleset-azurerm/releases/download/v"${AZURERM_VERSION}"/tflint-ruleset-azurerm_"${TARGETOS}"_"${TARGETARCH}".zip \
   && unzip /tmp/tflint-ruleset-azurerm.zip -d ~/.tflint.d/plugins \
   && rm /tmp/tflint-ruleset-azurerm.zip
 
-RUN wget -O /tmp/tflint-ruleset-google.zip https://github.com/terraform-linters/tflint-ruleset-google/releases/download/v"${GOOGLE_VERSION}"/tflint-ruleset-google_linux_amd64.zip \
+RUN wget -O /tmp/tflint-ruleset-google.zip https://github.com/terraform-linters/tflint-ruleset-google/releases/download/v"${GOOGLE_VERSION}"/tflint-ruleset-google_"${TARGETOS}"_"${TARGETARCH}".zip \
   && unzip /tmp/tflint-ruleset-google.zip -d ~/.tflint.d/plugins \
   && rm /tmp/tflint-ruleset-google.zip
 


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint-bundle/issues/47
See also https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/

This PR adds support for multi-arch (linux/amd64,linux/arm64/v8) images.