### PR TITLE
Bump rulesets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM --platform=$BUILDPLATFORM alpine:3.17.0 as builder
 ARG TARGETOS TARGETARCH
 
 ARG TFLINT_VERSION=0.43.0
-ARG AWS_VERSION=0.21.0
-ARG AZURERM_VERSION=0.19.0
-ARG GOOGLE_VERSION=0.22.0
+ARG AWS_VERSION=0.21.1
+ARG AZURERM_VERSION=0.20.0
+ARG GOOGLE_VERSION=0.22.1
 
 RUN wget -O /tmp/tflint.zip https://github.com/terraform-linters/tflint/releases/download/v"${TFLINT_VERSION}"/tflint_"${TARGETOS}"_"${TARGETARCH}".zip \
   && unzip /tmp/tflint.zip -d /usr/local/bin \

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ docker pull ghcr.io/terraform-linters/tflint-bundle
 Bundled versions:
 
 - TFLint v0.43.0
-- tflint-ruleset-aws v0.21.0
-- tflint-ruleset-azurerm v0.19.0
-- tflint-ruleset-google v0.22.0
+- tflint-ruleset-aws v0.21.1
+- tflint-ruleset-azurerm v0.20.0
+- tflint-ruleset-google v0.22.1
 
 These ruleset plugins are installed manually. If you want to enable it, just set `enabled = true` without specifying the version.
 


### PR DESCRIPTION
- AWS
  - https://github.com/terraform-linters/tflint-ruleset-aws/releases/tag/v0.21.1
- Azure
  - https://github.com/terraform-linters/tflint-ruleset-azurerm/releases/tag/v0.20.0
- Google
  - https://github.com/terraform-linters/tflint-ruleset-google/releases/tag/v0.22.1