### PR TITLE
improvement - run tflint binary as non-privileged user in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,20 @@ FROM alpine:3.17.0
 
 LABEL maintainer=terraform-linters
 
-RUN apk add --no-cache ca-certificates
+ARG USER=tflint
+ARG USER_ID=10001
+ARG GROUP=tflint
+ARG GROUP_ID=10001
+
+RUN addgroup -g ${GROUP_ID} ${GROUP} && \
+    adduser -h /home/${USER} -u ${USER_ID} -G ${GROUP} -D ${USER}
+
+RUN apk add --no-cache ca-certificates && update-ca-certificates
 
 COPY --from=builder /usr/local/bin/tflint /usr/local/bin
-COPY --from=builder /root/.tflint.d /root/.tflint.d
+COPY --from=builder --chown=${USER}:${GROUP} /root/.tflint.d /home/${USER}/.tflint.d
+
+USER ${USER}
+WORKDIR /data
 
 ENTRYPOINT ["tflint"]
-WORKDIR /data


### PR DESCRIPTION
This is an improvement for #68.

After building locally the container successfully run:

```bash
$ docker run -it --rm -v $(pwd):/data -e TFLINT_LOG=debug tflint-bundle --chdir=/data/terraform/pipeline
21:18:08 config.go:126: [INFO] Load config: .tflint.hcl
21:18:08 config.go:253: [DEBUG] Config loaded
21:18:08 config.go:254: [DEBUG]   Module: true
21:18:08 config.go:255: [DEBUG]   Force: false
21:18:08 config.go:256: [DEBUG]   IgnoreModules:
21:18:08 config.go:260: [DEBUG]   Varfiles:
21:18:08 config.go:261: [DEBUG]   Variables:
21:18:08 config.go:262: [DEBUG]   DisabledByDefault: false
21:18:08 config.go:263: [DEBUG]   PluginDir:
21:18:08 config.go:264: [DEBUG]   Format:
21:18:08 config.go:265: [DEBUG]   Rules:
21:18:08 config.go:269: [DEBUG]   Plugins:
21:18:08 config.go:271: [DEBUG]     terraform: enabled=true, version=, source=
21:18:08 config.go:271: [DEBUG]     aws: enabled=true, version=, source=
21:18:08 option.go:51: [DEBUG] CLI Options
21:18:08 option.go:52: [DEBUG]   Module: false
21:18:08 option.go:53: [DEBUG]   Force: false
21:18:08 option.go:54: [DEBUG]   IgnoreModules:
21:18:08 option.go:58: [DEBUG]   EnableRules:
21:18:08 option.go:59: [DEBUG]   DisableRules:
21:18:08 option.go:60: [DEBUG]   Only:
21:18:08 option.go:61: [DEBUG]   EnablePlugins:
21:18:08 option.go:62: [DEBUG]   Varfiles:
21:18:08 option.go:63: [DEBUG]   Variables:
21:18:08 option.go:64: [DEBUG]   Format:
21:18:08 loader.go:38: [INFO] Initialize new loader
21:18:08 module_mgr.go:63: [INFO] Module manifest file found. Initializing...
21:18:08 loader.go:80: [INFO] Module inspection is enabled. Building the root module with children...
21:18:08 loader.go:114: [DEBUG] Trying to load the module: key=core, version=, dir=../modules/vpc
21:18:08 loader.go:114: [DEBUG] Trying to load the module: key=env, version=, dir=../modules/env
21:18:08 loader.go:114: [DEBUG] Trying to load the module: key=key_pairs, version=, dir=../modules/key_pairs
21:18:08 runner.go:45: [INFO] Initialize new runner for root
21:18:08 runner.go:45: [INFO] Initialize new runner for module.env
21:18:08 runner.go:45: [INFO] Initialize new runner for module.key_pairs
21:18:08 runner.go:45: [INFO] Initialize new runner for module.core
21:18:08 discovery.go:33: [INFO] Plugin `terraform` is not installed, but the bundled plugin is available.
21:18:08 discovery.go:54: [INFO] Plugin `terraform` found
21:18:08 [WARN]  go-plugin@v1.4.8/client.go:569: plugin configured with a nil SecureConfig
21:18:08 [DEBUG] go-plugin@v1.4.8/client.go:603: starting plugin: path=/usr/local/bin/tflint args=["/usr/local/bin/tflint", "--act-as-bundled-plugin"]
21:18:08 [DEBUG] go-plugin@v1.4.8/client.go:611: plugin started: path=/usr/local/bin/tflint pid=11
21:18:08 [DEBUG] go-plugin@v1.4.8/client.go:706: waiting for RPC address: path=/usr/local/bin/tflint
21:18:08 [DEBUG] go-plugin@v1.4.8/client.go:751: using plugin: version=11
21:18:08 [DEBUG] go-plugin@v1.4.8/client.go:1045: tflint: 21:18:08 [DEBUG] go-plugin@v1.4.8/server.go:401: plugin address: network=unix address=/tmp/plugin3533568140
21:18:08 discovery.go:90: [DEBUG] Find plugin path: /home/tflint/.tflint.d/plugins/tflint-ruleset-aws
21:18:08 discovery.go:54: [INFO] Plugin `aws` found
21:18:08 [WARN]  go-plugin@v1.4.8/client.go:569: plugin configured with a nil SecureConfig
21:18:08 [DEBUG] go-plugin@v1.4.8/client.go:603: starting plugin: path=/home/tflint/.tflint.d/plugins/tflint-ruleset-aws args=["/home/tflint/.tflint.d/plugins/tflint-ruleset-aws"]
21:18:08 [DEBUG] go-plugin@v1.4.8/client.go:611: plugin started: path=/home/tflint/.tflint.d/plugins/tflint-ruleset-aws pid=18
21:18:08 [DEBUG] go-plugin@v1.4.8/client.go:706: waiting for RPC address: path=/home/tflint/.tflint.d/plugins/tflint-ruleset-aws
21:18:09 [DEBUG] go-plugin@v1.4.8/client.go:1045: tflint-ruleset-aws: 21:18:09 [DEBUG] go-plugin@v1.4.5/server.go:401: plugin address: network=unix address=/tmp/plugin2707919532
21:18:09 [DEBUG] go-plugin@v1.4.8/client.go:751: using plugin: version=11
21:18:09 [DEBUG] host2plugin/client.go:124: starting host-side gRPC server
21:18:09 [DEBUG] host2plugin/client.go:124: starting host-side gRPC server
21:18:09 [DEBUG] host2plugin/client.go:124: starting host-side gRPC server
21:18:09 [DEBUG] host2plugin/client.go:124: starting host-side gRPC server
21:18:09 [DEBUG] host2plugin/client.go:124: starting host-side gRPC server
21:18:09 [DEBUG] host2plugin/client.go:124: starting host-side gRPC server
21:18:09 [DEBUG] host2plugin/client.go:124: starting host-side gRPC server
21:18:10 [DEBUG] host2plugin/client.go:124: starting host-side gRPC server
21:18:10 [DEBUG] go-plugin@v1.4.8/grpc_stdio.go:139: stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
21:18:10 [INFO]  go-plugin@v1.4.8/client.go:664: plugin process exited: path=/usr/local/bin/tflint pid=11
21:18:10 [DEBUG] go-plugin@v1.4.8/client.go:469: plugin exited
21:18:10 [DEBUG] go-plugin@v1.4.8/grpc_stdio.go:139: stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
21:18:10 [INFO]  go-plugin@v1.4.8/client.go:664: plugin process exited: path=/home/tflint/.tflint.d/plugins/tflint-ruleset-aws pid=18
21:18:10 [DEBUG] go-plugin@v1.4.8/client.go:469: plugin exited
$ echo $?
0
```

```bash
$ docker run -it --rm --entrypoint=/bin/sh tflint-bundle
/data $ id
uid=10001(tflint) gid=10001(tflint) groups=10001(tflint)
/data $ pwd
/data
/data $ ls -la
total 0
drwxr-xr-x    1 tflint   tflint           0 Jan 17 21:12 .
drwxr-xr-x    1 root     root           142 Jan 17 21:27 ..
/data $ ls -la ~/.tflint.d/plugins/
total 71128
drwxr-xr-x    1 tflint   tflint         122 Jan 17 20:33 .
drwxr-sr-x    1 tflint   tflint          14 Jan 17 21:12 ..
-rwxr-xr-x    1 tflint   tflint    43470848 Jan 17 20:33 tflint-ruleset-aws
-rwxr-xr-x    1 tflint   tflint    13795328 Jan 17 20:33 tflint-ruleset-azurerm
-rwxr-xr-x    1 tflint   tflint    15568896 Jan 17 20:33 tflint-ruleset-google
/data $

```