### PR TITLE
Bump Google ruleset to v0.23.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETOS TARGETARCH
 ARG TFLINT_VERSION=0.46.0
 ARG AWS_VERSION=0.22.1
 ARG AZURERM_VERSION=0.22.0
-ARG GOOGLE_VERSION=0.23.0
+ARG GOOGLE_VERSION=0.23.1
 
 RUN wget -O /tmp/tflint.zip https://github.com/terraform-linters/tflint/releases/download/v"${TFLINT_VERSION}"/tflint_"${TARGETOS}"_"${TARGETARCH}".zip \
   && unzip /tmp/tflint.zip -d /usr/local/bin \

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Bundled versions:
 - TFLint v0.46.0
 - tflint-ruleset-aws v0.22.1
 - tflint-ruleset-azurerm v0.22.0
-- tflint-ruleset-google v0.23.0
+- tflint-ruleset-google v0.23.1
 
 These ruleset plugins are installed manually. If you want to enable it, just set `enabled = true` without specifying the version.
 


### PR DESCRIPTION
https://github.com/terraform-linters/tflint-ruleset-google/releases/tag/v0.23.1